### PR TITLE
Inny przykład niebezpiecznej funkcji niż strcpy

### DIFF
--- a/ochrona-QA.tex
+++ b/ochrona-QA.tex
@@ -970,7 +970,7 @@ Błąd przepełnienia bufora polega na tym, że ilość wprowadzanych danych prz
 
 \question Omów metody ochrony przed błędami przepełnienia bufora?
 \begin{solution}
-Główną metodą ochrony przed błędami przepełnienia bufora jest unikanie stosowania funkcji, które nie sprawdzają rozmiaru przyjmowanych danych, a w zamian używanie ich bezpieczniejszych odpowiedników (np. strncpy zamiast strcpy w C). Ogólnie rzecz ujmując, zawsze trzeba brać pod uwagę rozmiar przyjmowanych danych.
+Główną metodą ochrony przed błędami przepełnienia bufora jest unikanie stosowania funkcji, które nie sprawdzają rozmiaru przyjmowanych danych, a w zamian używanie ich bezpieczniejszych odpowiedników (np. fgets zamiast gets w C). Ogólnie rzecz ujmując, zawsze trzeba brać pod uwagę rozmiar przyjmowanych danych.
 \end{solution}
 
 \question Przedstaw najważniejsze zasady walidacji danych.


### PR DESCRIPTION
strncpy jest równie niebezpieczny jak strcpy w praktyce ze względu na to że nie pisze znaku końcowego (`'\0'`). Ze względu na to że właściwie ciągi danych C są niebezpieczne (przyznam że wolę używać memcpy lub strdup do kopiowania ciągów... lub lepiej, nie używać C), uznałem że wpiszę całkowicie inny bardziej realistyczny przykład